### PR TITLE
feat(effects): add Active Effects PoC behind reversible gate (spec 006)

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -3,6 +3,9 @@
     "notifications": {
       "dicePoolInvalid": "you cannot roll this test because your dice pool results in less than 1 die being kept."
     },
+    "effects": {
+      "armorPenalty": "Armor Penalty"
+    },
     "dialogs": {
       "characterRole": {
         "title": "Select the role of {actorName} in the house.",
@@ -66,6 +69,10 @@
       "isModifierDialogDefault": {
         "name": "Modifier Dialog as Default?",
         "hint": "if checked, when clicking on dice rolls on an actor's sheet, it will show the modifiers window, and will make the roll without showing the window when holding the SHIFT key. Each player defines his configuration."
+      },
+      "useActiveEffectsPoC": {
+        "name": "Use Active Effects (PoC)",
+        "hint": "EXPERIMENTAL spike gate. When ON, the armor equip penalty is applied through a native Active Effect instead of the built-in modifier path. Default OFF. Needs Foundry refresh (F5)."
       }
     },
     "sheets": {

--- a/module/actors/csCharacterActor.js
+++ b/module/actors/csCharacterActor.js
@@ -3,6 +3,7 @@ import { CSActor } from "./csActor.js";
 import SystemUtils from "../utils/systemUtils.js";
 import LOGGER from "../utils/logger.js";
 import { CSConstants } from "../system/csConstants.js";
+import { collectEffectModifiers } from "../effects/cs-effect-modifiers.js";
 
 /**
  * Extend the base Actor entity by defining a custom roll data structure which is ideal for the Simple system.
@@ -19,6 +20,37 @@ export class CSCharacterActor extends CSActor {
 
   prepareEmbeddedDocuments() {
     super.prepareEmbeddedDocuments();
+  }
+
+  /**
+   * Spike 006 — Active Effects PoC. Version-safe override that runs the
+   * effect-modifier collector in the "initial" phase, BUT only when the gate is
+   * ON. With the gate OFF it is a pass-through that merely delegates to super —
+   * inert, and emitting NO compatibility warning across the supported v13+
+   * range (Constitution floor; T024).
+   * @override
+   */
+  applyActiveEffects(phase) {
+    const isV14 = (game.release?.generation ?? 0) >= 14;
+    // Delegate with the signature each version expects: a phase argument is
+    // harmlessly ignored by v13 (no parameter), while omitting it in v14 would
+    // emit a deprecation warning.
+    if (isV14) {
+      super.applyActiveEffects(phase);
+    } else {
+      super.applyActiveEffects();
+    }
+
+    if (!ChronicleSystem.isActiveEffectsPoCEnabled()) return;
+
+    // v13 runs a single phase-less pass; treat it as "initial".
+    const effectivePhase = isV14 ? phase : "initial";
+    if (effectivePhase !== "initial") return;
+
+    LOGGER.trace(
+      `AE PoC: applyActiveEffects("initial") with gate ON → running collector for ${this.name} | csCharacterActor.js`
+    );
+    collectEffectModifiers(this);
   }
 
   prepareDerivedData() {

--- a/module/effects/cs-active-effect.js
+++ b/module/effects/cs-active-effect.js
@@ -1,0 +1,66 @@
+/* global ActiveEffect */
+import { ChronicleSystem } from "../system/ChronicleSystem.js";
+
+/**
+ * Spike 006 — Active Effects PoC.
+ *
+ * A thin ActiveEffect subclass whose only job is to suppress itself when its
+ * owning item is NOT equipped. Equipping/unequipping the armor therefore does
+ * NOT create or destroy the effect document — it only flips `system.equipped`,
+ * and because `prepareData` recomputes suppression every cycle the effect turns
+ * on/off by itself. This is what eliminates the "ghost" residue by construction
+ * (research Decision 3).
+ *
+ * Version-safe v13+v14: `active` derives from `isSuppressed` in BOTH versions,
+ * so overriding `isSuppressed` is the single portable hook. We never reference
+ * `CONFIG.ActiveEffect.legacyTransferral` (removed in v14) and never assume the
+ * effect appears in `actor.effects` (transferred in-place into
+ * `actor.appliedEffects` in v14).
+ */
+export class CSActiveEffect extends ActiveEffect {
+  /** @override */
+  get isSuppressed() {
+    const item = this.parent;
+    if (item?.documentName === "Item") {
+      const sys = item.system ?? {};
+      if (
+        "equipped" in sys &&
+        sys.equipped === ChronicleSystem.equippedConstants.IS_NOT_EQUIPPED
+      ) {
+        return true;
+      }
+    }
+    // Preserve native suppression (duration.expired / system.isSuppressed).
+    return super.isSuppressed;
+  }
+
+  /**
+   * PoC helper (T012): create the armor-penalty Active Effect on an armor item
+   * with `transfer: true` and the three domain-key changes. Usable from a macro
+   * or the console in the test world; the same effect can equally be authored by
+   * hand through the native item Effects UI (documented in the PoC trace).
+   *
+   * `mode: 2` (numeric ADD) is the portable creation format: native in v13 and
+   * silently migrated to `{ type: "add" }` in v14 without a compat warning.
+   *
+   * @param {Item} item  An armor item with `system.penalty` / `system.rating`.
+   * @returns {Promise<ActiveEffect[]>}
+   */
+  static async createArmorPenaltyEffect(item) {
+    const sys = item.system ?? {};
+    const penalty = Number(sys.penalty) || 0;
+    const rating = Number(sys.rating) || 0;
+    return item.createEmbeddedDocuments("ActiveEffect", [
+      {
+        name: game.i18n.localize("CS.effects.armorPenalty"),
+        img: "icons/svg/shield.svg",
+        transfer: true,
+        changes: [
+          { key: "cs.modifier.agility", value: penalty, mode: 2 },
+          { key: "cs.modifier.combat_defense", value: penalty, mode: 2 },
+          { key: "cs.modifier.damage_taken", value: rating, mode: 2 },
+        ],
+      },
+    ]);
+  }
+}

--- a/module/effects/cs-effect-modifiers.js
+++ b/module/effects/cs-effect-modifiers.js
@@ -1,0 +1,74 @@
+/**
+ * Spike 006 — Active Effects PoC: the effect-modifier collector.
+ *
+ * Bridges E2 (declarative AE changes) to E1 (the system's existing
+ * `actor.system.modifiers` map). Mirrors foundry-fe2's `_effectModifiers`
+ * pre-collection, but instead of inventing a new structure it reuses the
+ * chroniclesystem's own modifier map — so every existing consumer
+ * (`getActorTestFormula`, `calcCombatDefense`, `calculateMovementData`) sees the
+ * effect with zero changes (research Decision 1).
+ *
+ * Critical invariant (anti-corruption / anti double-count): the collector NEVER
+ * persists. It pushes into the in-memory `actor.system.modifiers` during
+ * `applyActiveEffects("initial")`; that map is reset from source at the start of
+ * the next `prepareData`, so entries never accumulate across cycles and never
+ * reach the saved document.
+ */
+
+import LOGGER from "../utils/logger.js";
+
+/** Domain-key prefix the PoC parses (research Decision 1). */
+export const CS_MODIFIER_PREFIX = "cs.modifier.";
+
+/**
+ * Resolve an AE change key into a chroniclesystem modifier type.
+ * `cs.modifier.agility` → `"agility"`. Returns null for unrelated keys.
+ * @param {string} key
+ * @returns {string|null}
+ */
+export function parseEffectKey(key) {
+  if (typeof key !== "string" || !key.startsWith(CS_MODIFIER_PREFIX)) {
+    return null;
+  }
+  const type = key.slice(CS_MODIFIER_PREFIX.length);
+  return type.length > 0 ? type : null;
+}
+
+/**
+ * Collect every active, applicable `cs.modifier.*` change and push it into the
+ * actor's in-memory modifier map. Idempotent within a prepare cycle: entries are
+ * keyed by `effect.id`, so re-running updates rather than duplicating.
+ *
+ * Portable v13+v14: `actor.appliedEffects` already filters by `effect.active`
+ * (not disabled AND not suppressed) in both versions, and `effect.changes` is a
+ * warning-free accessor in both (root field in v13, getter for `system.changes`
+ * in v14). We read only `change.key` / `change.value` — never `change.mode`.
+ *
+ * @param {Actor} actor
+ */
+export function collectEffectModifiers(actor) {
+  // Bind `actor.modifiers` to the live in-memory `system.modifiers` map.
+  actor.updateTempModifiers();
+
+  const effects = actor.appliedEffects;
+  let applied = 0;
+  for (const effect of effects) {
+    const changes = effect.changes ?? [];
+    for (const change of changes) {
+      const type = parseEffectKey(change.key);
+      if (!type) continue;
+      // isDocument=false: the source is an effect id, not an embedded Item id.
+      // save omitted (false): in-memory only — never touches the document.
+      actor.addModifier(type, effect.id, Number(change.value) || 0, false);
+      applied++;
+      LOGGER.trace(
+        `AE collector: "${effect.name}" → ${type} += ${
+          Number(change.value) || 0
+        } | cs-effect-modifiers.js`
+      );
+    }
+  }
+  LOGGER.trace(
+    `AE collector summary: ${actor.name} — appliedEffects=${effects.length}, cs.modifier changes applied=${applied} | cs-effect-modifiers.js`
+  );
+}

--- a/module/items/csArmorItem.js
+++ b/module/items/csArmorItem.js
@@ -10,6 +10,14 @@ export class CSArmorItem extends CSItem {
       } by the actor ${actor.name} | csArmorItem.js`
     );
     super.onEquippedChanged(actor, isEquipped);
+    // Spike 006 — Active Effects PoC gate. With the gate ON the armor penalty
+    // (AGILITY / COMBAT_DEFENSE / DAMAGE_TAKEN) is applied by the transferred
+    // Active Effect via the collector, so the built-in path must NOT run too —
+    // otherwise the penalty would be applied twice. BULK stays homemade
+    // (it originates in onObtained, not here). Gate OFF: unchanged behaviour.
+    if (ChronicleSystem.isActiveEffectsPoCEnabled()) {
+      return;
+    }
     if (isEquipped) {
       actor.addModifier(
         ChronicleSystem.modifiersConstants.AGILITY,

--- a/module/system/ChronicleSystem.js
+++ b/module/system/ChronicleSystem.js
@@ -226,6 +226,20 @@ ChronicleSystem.handleRoll = handleRoll;
 ChronicleSystem.handleRollAsync = handleRollAsync;
 ChronicleSystem.getActorAbilityFormula = getActorTestFormula;
 
+// Spike 006 — gate for the Active Effects PoC. Defensive: returns false if the
+// setting is not registered yet (e.g. called during very early data prep) so
+// the embedded PoC code stays inert with the gate OFF (FR-009 / SC-007).
+ChronicleSystem.isActiveEffectsPoCEnabled = function () {
+  try {
+    return !!game.settings.get(
+      CSConstants.Settings.SYSTEM_NAME,
+      CSConstants.Settings.USE_ACTIVE_EFFECTS_POC
+    );
+  } catch {
+    return false;
+  }
+};
+
 ChronicleSystem.dispositions = [
   new Disposition("CS.sheets.character.dispositions.affectionate", 1, -2, 5),
   new Disposition("CS.sheets.character.dispositions.friendly", 2, -1, 3),

--- a/module/system/config.js
+++ b/module/system/config.js
@@ -22,6 +22,7 @@ import { CSTechniqueItemSheet } from "../items/sheets/cs-technique-item-sheet.js
 import { migrateData } from "../migrations/migration.js";
 import { CsCombat } from "../combat/cs-combat.js";
 import { CsCombatant } from "../combat/cs-combatant.js";
+import { CSActiveEffect } from "../effects/cs-active-effect.js";
 
 // TypeDataModel classes
 import CharacterData from "../data/actor/character-data.js";
@@ -62,6 +63,10 @@ Hooks.once("init", async function () {
   CONFIG.Item.documentClass = itemConstructor;
   CONFIG.Combat.documentClass = CsCombat;
   CONFIG.Combatant.documentClass = CsCombatant;
+  // Spike 006 — Active Effects PoC. Inert with the gate OFF: the subclass only
+  // overrides suppression, so a registered-but-unused CSActiveEffect behaves
+  // exactly like the core ActiveEffect for worlds without opt-in (SC-007).
+  CONFIG.ActiveEffect.documentClass = CSActiveEffect;
 
   // Register TypeDataModel schemas
   CONFIG.Actor.dataModels = {
@@ -174,7 +179,7 @@ Hooks.once("ready", async () => {
   await migrateData();
 });
 
-Hooks.on("createItem", (item, data) => {
+Hooks.on("createItem", (item) => {
   if (!item.isEmbedded) {
     item.img = `systems/chroniclesystem/assets/icons/${item.type}.png`;
   }

--- a/module/system/csConstants.js
+++ b/module/system/csConstants.js
@@ -31,6 +31,7 @@ CSConstants.Settings = {
   DEBUG_LOGS: "debugLogs",
   CURRENT_VERSION: "version",
   MODIFIER_DIALOG_AS_DEFAULT: "isModifierDialogDefault",
+  USE_ACTIVE_EFFECTS_POC: "useActiveEffectsPoC",
 };
 
 CSConstants.HouseResources = {

--- a/module/system/settings.js
+++ b/module/system/settings.js
@@ -1,4 +1,3 @@
-/* global game */
 import LOGGER from "../utils/logger.js";
 import { CSConstants } from "./csConstants.js";
 
@@ -85,6 +84,29 @@ const registerSystemSettings = () => {
       onChange: (value) => {
         LOGGER.log(
           `Changed ${CSConstants.Settings.MODIFIER_DIALOG_AS_DEFAULT} to ${value}`
+        );
+      },
+    }
+  );
+
+  // Spike 006 — Active Effects PoC gate. World-scoped, default OFF so that
+  // worlds without opt-in behave exactly as before (FR-009 / SC-007). When ON,
+  // the armor equip penalty flows through a native Active Effect instead of the
+  // built-in addModifier path. Reversible: removing this registration plus the
+  // module/effects/ directory restores the current behaviour.
+  game.settings.register(
+    CSConstants.Settings.SYSTEM_NAME,
+    CSConstants.Settings.USE_ACTIVE_EFFECTS_POC,
+    {
+      name: "CS.settings.useActiveEffectsPoC.name",
+      hint: "CS.settings.useActiveEffectsPoC.hint",
+      scope: "world",
+      config: true,
+      type: Boolean,
+      default: false,
+      onChange: (value) => {
+        LOGGER.log(
+          `Changed ${CSConstants.Settings.USE_ACTIVE_EFFECTS_POC} to ${value}`
         );
       },
     }

--- a/tests/active-effects-parity.test.js
+++ b/tests/active-effects-parity.test.js
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest";
+import { ChronicleSystem } from "../module/system/ChronicleSystem.js";
+import {
+  collectEffectModifiers,
+  parseEffectKey,
+} from "../module/effects/cs-effect-modifiers.js";
+import { makeModifierActor, makeFakeEffect } from "./helpers/doubles.js";
+
+// Spec 006 — Active Effects PoC parity (FR-012 / contract P5). Pure-logic layer:
+// proves the effect collector pushes the SAME modifier totals into the SAME read
+// path (getModifier) as the homemade onEquippedChanged path (csArmorItem.js:14-28),
+// for the three armor targets. Transfer/suppression/UI are verified in a live
+// test world (quickstart Step 3); this guards the value-parity invariant cheaply.
+
+const M = ChronicleSystem.modifiersConstants;
+const PENALTY = 2;
+const RATING = 4;
+const EFFECT_ID = "effect-armor-1";
+const ARMOR_ID = "item-armor-1";
+
+// The three armor targets the AE covers (research Decision 5 / contract P2).
+// mode:2 = ADD (numeric, portable creation format v13+v14).
+const armorChanges = [
+  { key: "cs.modifier.agility", value: PENALTY, mode: 2 },
+  { key: "cs.modifier.combat_defense", value: PENALTY, mode: 2 },
+  { key: "cs.modifier.damage_taken", value: RATING, mode: 2 },
+];
+
+// Replicate the homemade path: actor.addModifier for each armor target.
+function applyHomemade(actor) {
+  actor.updateTempModifiers();
+  actor.addModifier(M.AGILITY, ARMOR_ID, PENALTY);
+  actor.addModifier(M.COMBAT_DEFENSE, ARMOR_ID, PENALTY);
+  actor.addModifier(M.DAMAGE_TAKEN, ARMOR_ID, RATING);
+}
+
+describe("active effects parity — key parser", () => {
+  it("maps cs.modifier.* keys to modifier types; ignores the rest", () => {
+    expect(parseEffectKey("cs.modifier.agility")).toBe("agility");
+    expect(parseEffectKey("cs.modifier.combat_defense")).toBe("combat_defense");
+    expect(parseEffectKey("cs.modifier.damage_taken")).toBe("damage_taken");
+    expect(parseEffectKey("system.derivedStats.value")).toBeNull();
+    expect(parseEffectKey("cs.modifier.")).toBeNull();
+    expect(parseEffectKey(undefined)).toBeNull();
+  });
+});
+
+describe("active effects parity — armor penalty totals", () => {
+  it("collector delta === homemade delta for agility / combat_defense / damage_taken", () => {
+    const targets = [M.AGILITY, M.COMBAT_DEFENSE, M.DAMAGE_TAKEN];
+
+    const homemade = makeModifierActor();
+    applyHomemade(homemade);
+
+    const ae = makeModifierActor({
+      appliedEffects: [makeFakeEffect(EFFECT_ID, armorChanges)],
+    });
+    collectEffectModifiers(ae);
+
+    for (const type of targets) {
+      const deltaHome = homemade.getModifier(type).total;
+      const deltaAe = ae.getModifier(type).total;
+      expect(deltaAe).toBe(deltaHome);
+    }
+
+    // Concrete values: penalty for the ability/defense targets, rating for damage.
+    expect(ae.getModifier(M.AGILITY).total).toBe(PENALTY);
+    expect(ae.getModifier(M.COMBAT_DEFENSE).total).toBe(PENALTY);
+    expect(ae.getModifier(M.DAMAGE_TAKEN).total).toBe(RATING);
+  });
+
+  it("a suppressed (unequipped) effect contributes nothing — no residue", () => {
+    // In production `appliedEffects` already filters out suppressed effects, so an
+    // unequipped armor's effect is simply absent. The collector must leave zeros.
+    const ae = makeModifierActor({ appliedEffects: [] });
+    collectEffectModifiers(ae);
+    expect(ae.getModifier(M.AGILITY).total).toBe(0);
+    expect(ae.getModifier(M.COMBAT_DEFENSE).total).toBe(0);
+    expect(ae.getModifier(M.DAMAGE_TAKEN).total).toBe(0);
+  });
+
+  it("re-collecting is idempotent — keyed by effect id, never double-counted", () => {
+    const ae = makeModifierActor({
+      appliedEffects: [makeFakeEffect(EFFECT_ID, armorChanges)],
+    });
+    collectEffectModifiers(ae);
+    collectEffectModifiers(ae);
+    expect(ae.getModifier(M.AGILITY).total).toBe(PENALTY);
+    expect(ae.getModifier(M.DAMAGE_TAKEN).total).toBe(RATING);
+  });
+
+  it("ignores non cs.modifier.* changes — bulk is never touched by the collector", () => {
+    const ae = makeModifierActor({
+      appliedEffects: [
+        makeFakeEffect(EFFECT_ID, [
+          { key: "system.unrelated", value: 9, mode: 2 },
+          { key: "cs.modifier.agility", value: PENALTY, mode: 2 },
+        ]),
+      ],
+    });
+    collectEffectModifiers(ae);
+    expect(ae.getModifier(M.AGILITY).total).toBe(PENALTY);
+    expect(ae.getModifier(M.BULK).total).toBe(0);
+  });
+});

--- a/tests/helpers/doubles.js
+++ b/tests/helpers/doubles.js
@@ -87,6 +87,38 @@ export function makeFakeActor({ abilities = [], data, modifiers = {} } = {}) {
 }
 
 /**
+ * A fake character actor that exercises the REAL modifier machinery
+ * (updateTempModifiers / addModifier / removeModifier / getModifier via the
+ * prototype) backed by a live `system.modifiers` object, plus an injectable
+ * `appliedEffects` list. Used by the Active Effects parity test (spec 006): it
+ * lets a test compare the homemade modifier total against the total pushed by
+ * the effect collector through the SAME read path (FR-012 / contract P5).
+ */
+export function makeModifierActor({ appliedEffects = [] } = {}) {
+  const system = { modifiers: {}, penalties: {} };
+  return {
+    system,
+    appliedEffects,
+    getCSData: () => system,
+    getEmbeddedDocument: () => null,
+    updateTempModifiers: proto.updateTempModifiers,
+    updateTempPenalties: proto.updateTempPenalties,
+    addModifier: proto.addModifier,
+    removeModifier: proto.removeModifier,
+    getModifier: proto.getModifier,
+    getPenalty: proto.getPenalty,
+  };
+}
+
+/**
+ * A minimal Active Effect double: an `id` plus a `changes` array. Mirrors the
+ * portable read path the collector uses (`effect.changes` with `{ key, value }`).
+ */
+export function makeFakeEffect(id, changes = []) {
+  return { id, changes };
+}
+
+/**
  * A fake weapon. `specialty` is read directly by the `weapon-test` helper;
  * `system.training` is read by adjustFormulaByWeapon; `getCSData()` feeds
  * updateDamageValue (damage formula, qualities, equipped slot).


### PR DESCRIPTION
Spike 006 - go/no-go on migrating the homemade modifiers/penalties system to native Active Effects. Implements a parity-verified PoC of the armor equip penalty as a transferred ActiveEffect, gated by a world setting (useActiveEffectsPoC, default OFF) so worlds without opt-in are unchanged.

- effects/cs-active-effect.js: CSActiveEffect, version-safe v13+v14 suppression by item `equipped`; static helper to author the effect
- effects/cs-effect-modifiers.js: collector that pushes cs.modifier.* changes into actor.system.modifiers in memory (never persists), run in applyActiveEffects("initial")
- csCharacterActor: version-safe applyActiveEffects override (inert with gate OFF, no compatibility warning)
- csArmorItem: gate short-circuits the homemade agility/combat_defense/ damage_taken path (anti double-apply); bulk stays homemade
- config/settings/ChronicleSystem/en.json: register documentClass, the gate setting + helper, and i18n keys
- tests: pure-logic parity test (collector vs homemade totals)

Also fixes two pre-existing ESLint errors in touched files (redundant global directive, unused param) so lint-staged passes.

Spec artifacts live under the gitignored specs/ and are not committed.