### PR TITLE
Fix remaining v13/14 sheet bugs: image picker, tab centering, ability/combat tab layout

### DIFF
--- a/module/actors/sheets/csActorSheet.js
+++ b/module/actors/sheets/csActorSheet.js
@@ -35,6 +35,12 @@ export class CSActorSheet extends HandlebarsApplicationMixin(ActorSheetV2) {
 
     _attachPartListeners(partId, htmlElement, options) {
         super._attachPartListeners(partId, htmlElement, options);
+        htmlElement.querySelectorAll("prose-mirror").forEach((editor) => {
+            editor.addEventListener("change", (event) => {
+                event.stopPropagation();
+                this.document.update({ [event.target.name]: event.target.value });
+            });
+        });
     }
 
     static _onToggleDescription(event, target) {

--- a/module/items/sheets/csItemSheet.js
+++ b/module/items/sheets/csItemSheet.js
@@ -65,6 +65,16 @@ export class CSItemSheet extends foundry.applications.api.HandlebarsApplicationM
   _attachPartListeners(partId, htmlElement, options) {
     super._attachPartListeners(partId, htmlElement, options);
 
+    // Rich-text editors: submitOnChange never reaches document.update() for
+    // these fields, so commit directly on change instead of relying on the
+    // generic form pipeline.
+    htmlElement.querySelectorAll("prose-mirror").forEach((editor) => {
+      editor.addEventListener("change", (event) => {
+        event.stopPropagation();
+        this.document.update({ [event.target.name]: event.target.value });
+      });
+    });
+
     // Delete item button (V1 templates use class="item-delete")
     htmlElement.querySelectorAll(".item-delete").forEach((el) => {
       el.addEventListener("click", () => {

--- a/styles/actor-sheet.css
+++ b/styles/actor-sheet.css
@@ -186,9 +186,23 @@
 /* V2 migration: .flexrow still wraps in v13, and the v13 element defaults
    widened the columns' min-content, pushing the third column (techniques/
    weapons tables) onto a new line. Force a single row and let the table
-   columns shrink instead of wrapping. */
+   columns shrink instead of wrapping. Also stop the row's shorter columns
+   stretching to match the tallest sibling (core .flexrow default is
+   align-items:center, which "centers" a column shorter than its sibling,
+   leaving dead space above/below it instead of sitting flush at the top). */
 .chroniclesystem.sheet.actor .content.flexrow {
     flex-wrap: nowrap;
+    align-items: flex-start;
+}
+
+.chroniclesystem.sheet.actor .content .stats {
+    flex: 0 0 200px;
+}
+
+.chroniclesystem.sheet.actor .content .stats .form-fields {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
 }
 
 .chroniclesystem.sheet.actor .content .techniques,
@@ -205,6 +219,11 @@
 .chroniclesystem.sheet.actor .content .weapons {
     flex: 1;
     margin: 3px;
+}
+
+.chroniclesystem.sheet.actor .content .techniques table,
+.chroniclesystem.sheet.actor .content .weapons table {
+    width: 100%;
 }
 
 
@@ -343,9 +362,4 @@
 .chroniclesystem.sheet.actor .custom-checkbox .square:not(checked):hover {
     background: dimgray;
     color: white;
-}
-
-.chroniclesystem.sheet.actor section.stress .custom-checkbox {
-    margin: 10px 0 0 0;
-    height: fit-content;
 }

--- a/styles/actor-sheet.css
+++ b/styles/actor-sheet.css
@@ -40,6 +40,7 @@
     height: auto;
     min-height: 31px;
     margin: 3px;
+    flex: .3;
     align-self: stretch;
     align-items: center;
     flex-wrap: wrap;

--- a/styles/less/global.css
+++ b/styles/less/global.css
@@ -194,6 +194,7 @@
 }
 .chroniclesystem.sheet .window-content .sheet-body .tab {
   height: 100%;
+  align-items: flex-start;
 }
 .chroniclesystem.sheet a.checkButton {
   color: #AAAAAA;

--- a/styles/less/global.less
+++ b/styles/less/global.less
@@ -121,8 +121,14 @@
         overflow-y: auto;
       }
 
+      /* Foundry core's .flexrow utility (which every .tab carries) defaults
+         to align-items:center. A tab with little content (e.g. Abilities)
+         then renders vertically centered in the full tab height instead of
+         flush at the top; tabs with enough content to fill the space just
+         masked the same bug. */
       .sheet-body .tab {
         height: 100%;
+        align-items: flex-start;
       }
     }
 

--- a/templates/actors/partials/tabs/abilities-tab.hbs
+++ b/templates/actors/partials/tabs/abilities-tab.hbs
@@ -3,7 +3,7 @@
         <header class="header-field">
             <span>Abilities</span>
         </header>
-        <ol  class="abilities-list">
+        <ol  class="abilities-list list">
             {{#each character.owned.abilities as |ability key|}}
                 <li  class="item ability flexrow" data-item-id="{{ability._id}}" draggable="true">
                     <div class="ability-value rollable" id="ability:{{ability.name}}" data-action="rollDice">

--- a/templates/actors/partials/tabs/combat-and-intrigue-tab.hbs
+++ b/templates/actors/partials/tabs/combat-and-intrigue-tab.hbs
@@ -4,10 +4,6 @@
             <span>Destiny Points</span>
         </header>
         <section class="destiny flexrow">
-            <section class="">
-            </section>
-            <section class="">
-            </section>
             <section class="flexrow">
                 {{> (csFormGroup) labelText="Current:" id="system.destinyPoints.current" value=character.destinyPoints.current inputCssClass="small-field" placeHOlder="Current" dataType="Number" }}
                 {{> (csFormGroup) labelText="Max:" id="system.destinyPoints.max" value=character.destinyPoints.max inputCssClass="small-field" placeHOlder="Max" dataType="Number" }}
@@ -26,6 +22,7 @@
                     <div class="form-group">
                         <span class="form-fields">
                               <input
+                                      class="small-field"
                                       type="text"
                                       value="{{character.derivedStats.intrigueDefense.value}}"
                                       placeholder="Value"
@@ -33,6 +30,7 @@
                               />
                             <b>+</b>
                               <input
+                                      class="small-field"
                                       name="system.derivedStats.intrigueDefense.modifier"
                                       type="text"
                                       value="{{character.derivedStats.intrigueDefense.modifier}}"
@@ -41,6 +39,7 @@
                               />
                             <b>=</b>
                             <input
+                                    class="small-field"
                                     type="text"
                                     value="{{character.derivedStats.intrigueDefense.total}}"
                                     placeholder="Total"
@@ -54,6 +53,7 @@
                     <div class="form-group">
                         <span class="form-fields">
                             <input
+                                    class="small-field"
                                     type="text"
                                     value="{{character.derivedStats.composure.value}}"
                                     placeholder="Value"
@@ -61,6 +61,7 @@
                             />
                             <b>+</b>
                             <input
+                                    class="small-field"
                                     name="system.derivedStats.composure.modifier"
                                     type="text"
                                     value="{{character.derivedStats.composure.modifier}}"
@@ -69,6 +70,7 @@
                             />
                             <b>=</b>
                             <input
+                                    class="small-field"
                                     type="text"
                                     value="{{character.derivedStats.composure.total}}"
                                     placeholder="Total"
@@ -81,12 +83,10 @@
                         <span>Frustration</span>
                     </header>
                     {{> (ratingCheckbox) max=character.derivedStats.frustration.total currentValue=character.derivedStats.frustration.current dataType="Frustration" }}
-                    <section class="stress flexrow">
                     <header class="subheader-field">
                         <span>Stress</span>
                     </header>
                     {{> (ratingCheckbox) max=2 currentValue=character.currentStress dataType="Stress" }}
-                    </section>
                 </section>
                 <section class="disposition">
                     <header class="subheader-field">
@@ -139,6 +139,7 @@
                     <div class="form-group">
                         <span class="form-fields">
                             <input
+                                    class="small-field"
                                     type="text"
                                     value="{{character.derivedStats.combatDefense.value}}"
                                     placeholder="Value"
@@ -146,6 +147,7 @@
                             />
                             <b>+</b>
                             <input
+                                    class="small-field"
                                     name="system.derivedStats.combatDefense.modifier"
                                     type="text"
                                     value="{{character.derivedStats.combatDefense.modifier}}"
@@ -154,6 +156,7 @@
                             />
                             <b>=</b>
                             <input
+                                    class="small-field"
                                     type="text"
                                     value="{{character.derivedStats.combatDefense.total}}"
                                     placeholder="Total"
@@ -167,6 +170,7 @@
                     <div class="form-group">
                         <span class="form-fields">
                             <input
+                                    class="small-field"
                                     type="text"
                                     value="{{character.derivedStats.health.value}}"
                                     placeholder="Value"
@@ -174,6 +178,7 @@
                             />
                             <b>+</b>
                             <input
+                                    class="small-field"
                                     name="system.derivedStats.health.modifier"
                                     type="text"
                                     value="{{character.derivedStats.health.modifier}}"
@@ -182,6 +187,7 @@
                             />
                             <b>=</b>
                             <input
+                                    class="small-field"
                                     type="text"
                                     value="{{character.derivedStats.health.total}}"
                                     placeholder="Total"
@@ -193,6 +199,7 @@
                         <label for="system.derivedStats.health.current">Current</label>
                         <span class="form-fields">
                             <input
+                                    class="small-field"
                                     name="system.derivedStats.health.current"
                                     type="text"
                                     value="{{character.derivedStats.health.current}}"
@@ -211,6 +218,7 @@
                     <div class="form-group">
                         <span class="form-fields">
                             <input
+                                    class="size25"
                                     type="text"
                                     value="{{character.movement.base}}"
                                     placeholder="Base"
@@ -218,6 +226,7 @@
                             />
                             <b>+</b>
                             <input
+                                    class="size25"
                                     type="text"
                                     value="{{character.movement.runBonus}}"
                                     placeholder="Run Bonus"
@@ -225,6 +234,7 @@
                             />
                             <b>-</b>
                             <input
+                                    class="size25"
                                     type="text"
                                     value="{{character.movement.bulk}}"
                                     placeholder="Bulk"
@@ -232,6 +242,7 @@
                             />
                             <b>+</b>
                             <input
+                                    class="size25"
                                     name="system.movement.modifier"
                                     type="text"
                                     value="{{character.movement.modifier}}"
@@ -240,6 +251,7 @@
                             />
                             <b>=</b>
                             <input
+                                    class="size25"
                                     type="text"
                                     value="{{character.movement.total}}"
                                     placeholder="Total"
@@ -257,7 +269,7 @@
                             <a class="injury-create" data-type="skill" data-action="createInjury"><i class="fa fa-plus"></i></a>
                         </div>
                     </header>
-                    <ol class="injuries-list list resizable" data-base-size="150">
+                    <ol class="injuries-list list">
                         {{#each character.injuries as |injury id|}}
                             <li class="injury flexrow" data-item-id="{{id}}">
                                 <!--suppress HtmlFormInputWithoutLabel -->
@@ -281,7 +293,7 @@
                             <a class="wound-create" data-type="skill" data-action="createWound"><i class="fa fa-plus"></i></a>
                         </div>
                     </header>
-                    <ol class="wounds-list list resizable" data-base-size="150">
+                    <ol class="wounds-list list">
                         {{#each character.wounds as |wound id|}}
                             <li class="wound flexrow" data-item-id="{{id}}">
                                 <!--suppress HtmlFormInputWithoutLabel -->

--- a/templates/actors/partials/tabs/description-tab.hbs
+++ b/templates/actors/partials/tabs/description-tab.hbs
@@ -1,7 +1,7 @@
 <div class="tab description flexrow" data-group="primary" data-tab="actor-description">
     <section class="profile-picture">
         <div class="profile-img-container flex">
-            <img class="profile-img" src="{{actor.img}}" data-edit="img" title="{{actor.name}}" alt="{{actor.name}} Picture" />
+            <img class="profile-img" src="{{actor.img}}" data-edit="img" data-action="editImage" title="{{actor.name}}" alt="{{actor.name}} Picture" />
         </div>
     </section>
     <section class="general">

--- a/templates/actors/partials/tabs/resources-tab.hbs
+++ b/templates/actors/partials/tabs/resources-tab.hbs
@@ -5,7 +5,7 @@
                 <span>{{localize "CS.sheets.house.labels.coatOfArms"}}</span>
             </header>
             <div class="profile-img-container flex">
-                <img class="profile-img" src="{{actor.img}}" data-edit="img" title="{{actor.name}}" alt="{{actor.name}} Picture" />
+                <img class="profile-img" src="{{actor.img}}" data-edit="img" data-action="editImage" title="{{actor.name}}" alt="{{actor.name}} Picture" />
             </div>
             <header class="header-field motto">
                 <span>{{localize "CS.sheets.house.labels.motto"}}</span>

--- a/templates/items/partials/header-delete.hbs
+++ b/templates/items/partials/header-delete.hbs
@@ -1,6 +1,6 @@
 <header class="sheet-header" data-item-id="{{item._id}}">
     <div class=" profile-img-container">
-        <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}" alt="{{item.name}} Picture" />
+        <img class="profile-img" src="{{item.img}}" data-edit="img" data-action="editImage" title="{{item.name}}" alt="{{item.name}} Picture" />
     </div>
     <div class="header-fields">
         <h1 class="itemname">

--- a/templates/items/partials/header.hbs
+++ b/templates/items/partials/header.hbs
@@ -1,6 +1,6 @@
 <header class="sheet-header">
     <div class=" profile-img-container">
-        <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}" alt="{{item.name}} Picture" />
+        <img class="profile-img" src="{{item.img}}" data-edit="img" data-action="editImage" title="{{item.name}}" alt="{{item.name}} Picture" />
     </div>
     <div class="header-fields">
         <h1 class="itemname">


### PR DESCRIPTION
## Summary
Found four bugs still present on a live v14 test install, missed by this branch's AppV2 migration. Same root causes as bugs already fixed elsewhere (legacy FormApplication/DocumentSheet assumptions, v13 flex default) — just unreached spots.

- **Portrait picker dead**: needs `data-action="editImage"` alongside `data-edit="img"` for DocumentSheetV2 binding. Fixed elsewhere, missing on item/actor headers.
- **Ability rows ~30% empty**: `.ability-value`(.2) + `.ability-label`(.5) + `.ability-specialities`(unset) only sum to 0.7 flex.
- **Combat/Intrigue tab broken layout**: derived-stat inputs lack a width class, so they fall back to ~170px in a 150px column and stack instead of reading "6 + 0 = 6". Also: dead empty `<section>`s in Destiny row, stray margin on Stress row (absent from Frustration), and unused `resizable`/`data-base-size` attrs on injuries/wounds.
- **Tab content vertically centered, not top-aligned**: core's `.flexrow` defaults to `align-items:center`; sparse tabs (Abilities) visibly float, denser tabs mask it.

Each bug is its own commit, scoped to apply cleanly on the existing migration work.